### PR TITLE
Implements multiple outputs to account for package name change (close…

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+target_platform:
+- linux-64

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pytest--check-green.svg)](https://anaconda.org/conda-forge/pytest-check) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest-check.svg)](https://anaconda.org/conda-forge/pytest-check) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest-check.svg)](https://anaconda.org/conda-forge/pytest-check) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest-check.svg)](https://anaconda.org/conda-forge/pytest-check) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pytest_check-green.svg)](https://anaconda.org/conda-forge/pytest_check) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest_check.svg)](https://anaconda.org/conda-forge/pytest_check) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest_check.svg)](https://anaconda.org/conda-forge/pytest_check) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest_check.svg)](https://anaconda.org/conda-forge/pytest_check) |
 
 Installing pytest-check
 =======================
@@ -39,16 +40,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pytest-check` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `pytest-check, pytest_check` can be installed with `conda`:
 
 ```
-conda install pytest-check
+conda install pytest-check pytest_check
 ```
 
 or with `mamba`:
 
 ```
-mamba install pytest-check
+mamba install pytest-check pytest_check
 ```
 
 It is possible to list all of the versions of `pytest-check` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 1
 
 outputs:
-  - name: {{ name }}
+  - name: pytest-check
 
     build:
       noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,17 +43,23 @@ outputs:
         - pytest
 
   - name: {{ name|replace("-","_") }}
+
     # Meta-package to the main package, that just installs it
     # it is here to keep-up with the legacy name, containing an
     # underscore ("_") instead of a dash.
     build:
       noarch: python
+
     requirements:
       host:
         - python >=3.8
       run:
         - python >=3.8
         - {{ pin_subpackage(name, exact=True) }}
+
+    test:
+      imports:
+        - pytest_check
 
 about:
   home: https://github.com/okken/pytest-check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,39 +10,56 @@ source:
   sha256: 1c93bac3c45881a4aa5e1fcf6f0dccad9ee66df178de4ef90376be28fc249a10
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
-requirements:
-  host:
-    - flit-core >=3.2,<4
-    - pip
-    - python >=3.8
-  run:
-    - colorama >=0.4.6
-    - pytest
-    - python >=3.8
+outputs:
+  - name: {{ name }}
 
-test:
-  imports:
-    - pytest_check
-  requires:
-    - pip
-  source_files:
-    - tests/
-    - examples/
-    - tox.ini
-  commands:
-    - pip check
-    - pytest
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . -vv
+
+    requirements:
+      host:
+        - python >=3.8
+        - flit-core >=3.2,<4
+        - pip
+      run:
+        - python >=3.8
+        - colorama >=0.4.6
+        - pytest
+
+    test:
+      imports:
+        - pytest_check
+      requires:
+        - pip
+      source_files:
+        - tests/
+        - examples/
+        - tox.ini
+      commands:
+        - pip check
+        - pytest
+
+  - name: {{ name|replace("-","_") }}
+    # Meta-package to the main package, that just installs it
+    # it is here to keep-up with the legacy name, containing an
+    # underscore ("_") instead of a dash.
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.8
+      run:
+        - python >=3.8
+        - {{ pin_subpackage(name, exact=True) }}
 
 about:
   home: https://github.com/okken/pytest-check
   summary: A pytest plugin that allows multiple failures per test.
   license: MIT
   license_file: LICENSE.txt
-
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ outputs:
 
     build:
       noarch: python
-      script: ${PYTHON} -m pip install . -vv --no-deps
+      script: ${PYTHON} -m pip install . -vv --no-deps --no-build-isolation
 
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ outputs:
 
     build:
       noarch: python
-      script: {{ PYTHON }} -m pip install . -vv
+      script: ${PYTHON} -m pip install . -vv
 
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "pytest-check" %}
+{% set name = "pytest-check-meta" %}
 {% set version = "1.1.3" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytest-check-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/pytest-check/pytest-check-{{ version }}.tar.gz
   sha256: 1c93bac3c45881a4aa5e1fcf6f0dccad9ee66df178de4ef90376be28fc249a10
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ outputs:
         - pip check
         - pytest
 
-  - name: {{ name|replace("-","_") }}
+  - name: pytest_check
 
     # Meta-package to the main package, that just installs it
     # it is here to keep-up with the legacy name, containing an
@@ -55,7 +55,7 @@ outputs:
         - python >=3.8
       run:
         - python >=3.8
-        - {{ pin_subpackage(name, exact=True) }}
+        - {{ pin_subpackage("pytest-check", exact=True) }}
 
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ outputs:
 
     build:
       noarch: python
-      script: ${PYTHON} -m pip install . -vv
+      script: ${PYTHON} -m pip install . -vv --no-deps
 
     requirements:
       host:


### PR DESCRIPTION
…s #3)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This fixes #3 by providing a second "meta-package", with the legacy name (ie. `pytest_check`), that solely depends on `pytest-check` itself.  The user may install any and the installation should just work (tm).